### PR TITLE
Add instructions for Firefox to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Griffpatch's Scratch 3 Dev Tools Chrome Browser Extension
 
-Welcome all - This is a chrome extension I'm developing to add new complementry features to the awesome [Scratch](https://scratch.mit.edu) website. The source code is provided here for you to see, but you can more easily download the official extension from the [Google Chrome Webstore](https://chrome.google.com/webstore/detail/scratch-3-developer-tools/phacniajokfchdcamjhonkbhlcipplno)
+Welcome all - This is a chrome extension I'm developing to add new complementary features to the awesome [Scratch](https://scratch.mit.edu) website. The source code is provided here for you to see, but you can more easily download the official extension from the [Google Chrome Webstore](https://chrome.google.com/webstore/detail/scratch-3-developer-tools/phacniajokfchdcamjhonkbhlcipplno).
 
 ## Getting Started
 
@@ -10,19 +10,30 @@ If you want to build it yourself, or see how it works, then the following instru
 
 ### Prerequisites
 
-What things you need to install the software and how to install them
-
-```
-Nothing really, just Google Chrome or Chromium
-```
+Google Chrome / Chromium or Firefox
 
 ### Installing
 
-1. Copy all files into a folder on your PC
-2. Open Google Chrome and navigate to: `chrome://extensions/`
-3. Click the `Load Unpacked` button (top left)
-4. Select the folder containing the extension files
-5. Navigate to a scratch project at https://scratch.mit.edu/ and look inside
+First you'll need to download the files. You can do this with the "Clone or download" button here on GitHub, or clone this repository:
+```bash
+git clone https://github.com/griffpatch/Scratch3-Dev-Tools
+```
+
+#### Installing (Chrome / Chromium)
+
+1. Open Google Chrome and navigate to: `chrome://extensions/`
+2. Click the `Load Unpacked` button (top left)
+3. Select the folder containing the extension files
+4. Navigate to a Scratch project at https://scratch.mit.edu/ and look inside
+5. Enjoy!
+
+#### Installing (Firefox)
+
+1. Open Firefox and navigate to: `about:debugging`
+2. Click `This Firefox`
+3. Click `Load Temporary Add-on...`
+4. Open the folder containing the extension files, and choose the `manifest.json` file
+5. Navigate to a Scratch project at https://scratch.mit.edu/ and look inside
 6. Enjoy!
 
 ## Versioning
@@ -37,7 +48,7 @@ v0.0.1 - Initial Release
 
 ## License
 
-This project is licensed under the GNU Public License 3 - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the GNU General Public License v3 - see the [LICENSE.md](LICENSE.md) file for details
 
 ## Acknowledgments
 


### PR DESCRIPTION
It turns out Firefox and Chrome use the same extension API, and this easily runs on Firefox!

I added instructions for doing so to the README, and did a bit of copy-editing as well.