### PR TITLE
Expose Runtime (and other modules) to the browser window

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,24 +9,3 @@ chrome.webRequest.onBeforeRequest.addListener(
     {urls: ["*://scratch.mit.edu/*.js"]},
     ["blocking"]
 );
-
-/*
-const file_url = 'https://joeclinton1.github.io/Scratch3-Dev-Tools/projects.bundle.js';
-//Listener which allows for cross-origin sharing. 
-chrome.webRequest.onHeadersReceived.addListener(
-    function(details) {
-        if( details.url == file_url)
-            responseHeaders = details.responseHeaders.map(item => {
-                if (item.name.toLowerCase() === 'access-control-allow-origin') {
-                item.value = '*'
-                }
-            })
-            
-            return {
-                responseHeaders
-            };
-    },      
-    {urls: ["*://<domain here>/*.js"]},
-    ['blocking','responseHeaders', 'extraHeaders']
-);
-*/

--- a/background.js
+++ b/background.js
@@ -1,3 +1,4 @@
+// Listen for requests and if the request is for projects.bundle.js then block it
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {
         if( details.url == "https://scratch.mit.edu/js/projects.bundle.js" ){

--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {
         if( details.url == "https://scratch.mit.edu/js/projects.bundle.js" )
-            return {redirectUrl: "https://github.com/Joeclinton1/Scratch3-Dev-Tools/blob/master/projects.bundle.js" };
+            return {redirectUrl: "https://raw.githubusercontent.com/Joeclinton1/Scratch3-Dev-Tools/master/projects.bundle.js" };
     },
     {urls: ["*://scratch.mit.edu/*.js"]},
     ["blocking"]

--- a/background.js
+++ b/background.js
@@ -1,0 +1,8 @@
+chrome.webRequest.onBeforeRequest.addListener(
+    function(details) {
+        if( details.url == "https://scratch.mit.edu/js/projects.bundle.js" )
+            return {redirectUrl: "https://github.com/Joeclinton1/Scratch3-Dev-Tools/blob/master/projects.bundle.js" };
+    },
+    {urls: ["*://scratch.mit.edu/*.js"]},
+    ["blocking"]
+);

--- a/background.js
+++ b/background.js
@@ -1,8 +1,29 @@
+const file_url = 'https://joeclinton1.github.io/Scratch3-Dev-Tools/projects.bundle.js'
+
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {
         if( details.url == "https://scratch.mit.edu/js/projects.bundle.js" )
-            return {redirectUrl: "https://raw.githubusercontent.com/Joeclinton1/Scratch3-Dev-Tools/master/projects.bundle.js" };
-    },
+            return {
+                redirectUrl: file_url,
+            };
+    },      
     {urls: ["*://scratch.mit.edu/*.js"]},
     ["blocking"]
+);
+
+chrome.webRequest.onHeadersReceived.addListener(
+    function(details) {
+        if( details.url == file_url)
+            responseHeaders = details.responseHeaders.map(item => {
+                if (item.name.toLowerCase() === 'access-control-allow-origin') {
+                item.value = '*'
+                }
+            })
+            
+            return {
+                responseHeaders
+            };
+    },      
+    {urls: ["*://joeclinton1.github.io/*.js"]},
+    ['blocking','responseHeaders', 'extraHeaders']
 );

--- a/background.js
+++ b/background.js
@@ -1,16 +1,18 @@
-const file_url = 'https://joeclinton1.github.io/Scratch3-Dev-Tools/projects.bundle.js'
-
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {
-        if( details.url == "https://scratch.mit.edu/js/projects.bundle.js" )
-            return {
-                redirectUrl: file_url,
-            };
+        if( details.url == "https://scratch.mit.edu/js/projects.bundle.js" ){
+            return {cancel: true};
+        }else{
+            return{};
+        }
     },      
     {urls: ["*://scratch.mit.edu/*.js"]},
     ["blocking"]
 );
 
+/*
+const file_url = 'https://joeclinton1.github.io/Scratch3-Dev-Tools/projects.bundle.js';
+//Listener which allows for cross-origin sharing. 
 chrome.webRequest.onHeadersReceived.addListener(
     function(details) {
         if( details.url == file_url)
@@ -24,6 +26,7 @@ chrome.webRequest.onHeadersReceived.addListener(
                 responseHeaders
             };
     },      
-    {urls: ["*://joeclinton1.github.io/*.js"]},
+    {urls: ["*://<domain here>/*.js"]},
     ['blocking','responseHeaders', 'extraHeaders']
 );
+*/

--- a/inject3.js
+++ b/inject3.js
@@ -1697,7 +1697,7 @@ function initGUI() {
                                         <div class="goog-menuitem-content" style="user-select: none;">Cut Block</div>
                                     </div>
                                     <div id="s3devTimeBlock" class="goog-menuitem s3dev-mi" role="menuitem" style="user-select: none; border-top: 1px solid hsla(0, 0%, 0%, 0.15);">
-                                        <div class="goog-menuitem-content" style="user-select: none;">Time block</div>
+                                        <div class="goog-menuitem-content" style="user-select: none;">Time this stack</div>
                                     </div>
 
                                 `);
@@ -1739,7 +1739,7 @@ function initGUI() {
 
                         copyDiv = blocklyContextMenu.querySelector("div#s3devTimeBlock");
                         if (copyDiv) {
-                            copyDiv.addEventListener("click", function(e) { timeBlock(e)} );
+                            copyDiv.addEventListener("click", function() { timeStack(dataId)} );
                         }
 
                         copyDiv = blocklyContextMenu.querySelector("div#s3devReplaceAllVars");
@@ -2311,6 +2311,28 @@ function initGUI() {
         }
         p.append(dd);
     }
+
+    function timeStack(topBlockId){
+        var timeElapsed = 0
+        var thread;
+        const STATUS_DONE = 4;
+        var threadEnded = false
+        Runtime.enableProfiling((frame)=>{
+            if(frame.id == 0 && thread.status != STATUS_DONE){
+                timeElapsed += frame.totalTime
+            }
+            if(thread.status == STATUS_DONE && !threadEnded){
+                Runtime.disableProfiling();
+                console.log(timeElapsed/0.75); // time must be divided by 0.75
+                threadEnded = true;
+            }
+        })
+        var opts = {
+            stackClick: true, 
+            target: Runtime._editingTarget
+        }
+        thread = Runtime._pushThread(topBlockId, opts.target, opts);
+    }   
 
     setTimeout(initInner, 1000);
 

--- a/inject3.js
+++ b/inject3.js
@@ -1696,6 +1696,10 @@ function initGUI() {
                                     <div id="s3devCutBlock" class="goog-menuitem s3dev-mi" role="menuitem" style="user-select: none;">
                                         <div class="goog-menuitem-content" style="user-select: none;">Cut Block</div>
                                     </div>
+                                    <div id="s3devTimeBlock" class="goog-menuitem s3dev-mi" role="menuitem" style="user-select: none; border-top: 1px solid hsla(0, 0%, 0%, 0.15);">
+                                        <div class="goog-menuitem-content" style="user-select: none;">Time block</div>
+                                    </div>
+
                                 `);
                             }
 
@@ -1732,6 +1736,12 @@ function initGUI() {
                         if (copyDiv) {
                             copyDiv.addEventListener("click", function(e) { eventCopyClick(e, 2); } );
                         }
+
+                        copyDiv = blocklyContextMenu.querySelector("div#s3devTimeBlock");
+                        if (copyDiv) {
+                            copyDiv.addEventListener("click", function(e) { timeBlock(e)} );
+                        }
+
                         copyDiv = blocklyContextMenu.querySelector("div#s3devReplaceAllVars");
                         if (copyDiv) {
                             copyDiv.addEventListener("click", clickReplace);
@@ -1955,7 +1965,7 @@ function initGUI() {
                 e.preventDefault();
                 return;
 
-                // data_variable
+                // data_variable1
                 // block.getVars()[0].id
 
                 // block.inputList[0].fieldRow[0].getText()

--- a/inject3.js
+++ b/inject3.js
@@ -1696,10 +1696,6 @@ function initGUI() {
                                     <div id="s3devCutBlock" class="goog-menuitem s3dev-mi" role="menuitem" style="user-select: none;">
                                         <div class="goog-menuitem-content" style="user-select: none;">Cut Block</div>
                                     </div>
-                                    <div id="s3devTimeBlock" class="goog-menuitem s3dev-mi" role="menuitem" style="user-select: none; border-top: 1px solid hsla(0, 0%, 0%, 0.15);">
-                                        <div class="goog-menuitem-content" style="user-select: none;">Time this stack</div>
-                                    </div>
-
                                 `);
                             }
 
@@ -1736,12 +1732,6 @@ function initGUI() {
                         if (copyDiv) {
                             copyDiv.addEventListener("click", function(e) { eventCopyClick(e, 2); } );
                         }
-
-                        copyDiv = blocklyContextMenu.querySelector("div#s3devTimeBlock");
-                        if (copyDiv) {
-                            copyDiv.addEventListener("click", function() { timeStack(dataId)} );
-                        }
-
                         copyDiv = blocklyContextMenu.querySelector("div#s3devReplaceAllVars");
                         if (copyDiv) {
                             copyDiv.addEventListener("click", clickReplace);
@@ -1965,7 +1955,7 @@ function initGUI() {
                 e.preventDefault();
                 return;
 
-                // data_variable1
+                // data_variable
                 // block.getVars()[0].id
 
                 // block.inputList[0].fieldRow[0].getText()
@@ -2311,28 +2301,6 @@ function initGUI() {
         }
         p.append(dd);
     }
-
-    function timeStack(topBlockId){
-        var timeElapsed = 0
-        var thread;
-        const STATUS_DONE = 4;
-        var threadEnded = false
-        Runtime.enableProfiling((frame)=>{
-            if(frame.id == 0 && thread.status != STATUS_DONE){
-                timeElapsed += frame.totalTime
-            }
-            if(thread.status == STATUS_DONE && !threadEnded){
-                Runtime.disableProfiling();
-                console.log(timeElapsed/0.75); // time must be divided by 0.75
-                threadEnded = true;
-            }
-        })
-        var opts = {
-            stackClick: true, 
-            target: Runtime._editingTarget
-        }
-        thread = Runtime._pushThread(topBlockId, opts.target, opts);
-    }   
 
     setTimeout(initInner, 1000);
 

--- a/injectSimple.js
+++ b/injectSimple.js
@@ -1,17 +1,37 @@
-const s = document.createElement('script');
-// TODO: add "script.js" to web_accessible_resources in manifest.json
-s.src = chrome.runtime.getURL('inject3.js');
-s.onload = function() {
-    this.remove();
-};
-(document.head || document.documentElement).appendChild(s);
-/*
+
+//Load project.bundle.js synchronously and insert code to expose the runtime module to the window
+xhr = new window.XMLHttpRequest;
+xhr.open('GET', 'https://scratch.mit.edu/js/projects.bundle.js?_=0', false);
+xhr.send();
+var text = xhr.responseText
+var insertPos = text.search('this.runtime');
+jsCode = text.slice(0,insertPos) + 'window.Runtime=t,' + text.slice(insertPos);
+var blob = new Blob([jsCode], {
+    type: 'text/javascript'
+});
+
+const s1 = document.createElement('script');
+var url = (window.URL ? URL : webkitURL).createObjectURL(blob)
+s1.setAttribute('src', url);
+(document.head || document.documentElement).appendChild(s1);
+
+
+
 const s2 = document.createElement('script');
-// TODO: add "math.js" to web_accessible_resources in manifest.json
-s2.src = chrome.runtime.getURL('math.js');
+// TODO: add "script.js" to web_accessible_resources in manifest.json
+s2.src = chrome.runtime.getURL('inject3.js');
 s2.onload = function() {
     this.remove();
 };
 (document.head || document.documentElement).appendChild(s2);
+
+/*
+const s3 = document.createElement('script');
+// TODO: add "math.js" to web_accessible_resources in manifest.json
+s3.src = chrome.runtime.getURL('math.js');
+s3.onload = function() {
+    this.remove();
+};
+(document.head || document.documentElement).appendChild(s3);
 */
 

--- a/injectSimple.js
+++ b/injectSimple.js
@@ -5,7 +5,6 @@ s.onload = function() {
     this.remove();
 };
 (document.head || document.documentElement).appendChild(s);
-
 /*
 const s2 = document.createElement('script');
 // TODO: add "math.js" to web_accessible_resources in manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -29,8 +29,19 @@
       "all_frames": false
     }
   ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  },
+
   "web_accessible_resources": [
     "inject3.js",
     "youtubeIcon.png"
+  ],
+  "permissions": [
+    "background",
+    "webRequest",
+    "*://scratch.mit.edu/",
+    "webRequestBlocking"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -41,7 +41,8 @@
   "permissions": [
     "background",
     "webRequest",
+    "webRequestBlocking",
     "*://scratch.mit.edu/",
-    "webRequestBlocking"
+    "*://raw.githubusercontent.com/"
   ]
 }


### PR DESCRIPTION
This code gives the extension access to more scratch modules, and will work without any need for a proxy.

This is how it works:

1. It uses the webrequest module to block the request for the projects.bundle.js file before the request is sent. (redirecting to my own edited file, was considered but I wanted it to be more flexible and not break if the scratch code is updated)
2. In injectSimple.js, it requests the file separately and inserts "window.runtime = this.runtime" just after runtime is defined.
3. It injects the modified script into the document.

A current issue:

- it requires a synchronous XMLHttpRequest which is deprecated because of it's "detrimental effects to the end user's experience", so this will cause the extension to show an error. However, there is no actual negative effect i've found of using an XMLHttpRequest.